### PR TITLE
Use Flank --dry option to remove the need for credentials on tests

### DIFF
--- a/src/main/kotlin/FlankRunTask.kt
+++ b/src/main/kotlin/FlankRunTask.kt
@@ -20,6 +20,9 @@ abstract class FlankRunTask : DefaultTask() {
   @get:Input
   val dumpShards: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(false)
 
+  @get:Input
+  val dry: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(false)
+
   @get:InputFile
   @get:PathSensitive(PathSensitivity.NONE)
   abstract val serviceAccountCredentials: RegularFileProperty
@@ -74,12 +77,12 @@ abstract class FlankRunTask : DefaultTask() {
           mainClass.set("ftl.Main")
           environment(
               mapOf("GOOGLE_APPLICATION_CREDENTIALS" to serviceAccountCredentials.get().asFile))
-          args =
-              if (dumpShards.get()) {
-                listOf("firebase", "test", "android", "run", "--dump-shards")
-              } else {
-                listOf("firebase", "test", "android", "run")
-              }
+          args = listOf("firebase", "test", "android", "run")
+          if (dumpShards.get()) args("--dump-shards")
+          if (dry.get()) args("--dry")
+
+          logger.lifecycle(args.toString())
+
           workingDir(this@FlankRunTask.workingDir)
         }
         .assertNormalExitValue()

--- a/src/main/kotlin/simple-flank.gradle.kts
+++ b/src/main/kotlin/simple-flank.gradle.kts
@@ -121,6 +121,8 @@ fun registerFlankRun(
       this.testApkDir.set(testApkDir)
       val dumpShards: String? by project
       this@register.dumpShards.set(dumpShards.toBoolean())
+      val dry: String? by project
+      this@register.dry.set(dry.toBoolean())
     }
 
 fun registerFlankDoctor(

--- a/src/test/kotlin/GradleTest.kt
+++ b/src/test/kotlin/GradleTest.kt
@@ -13,7 +13,7 @@ abstract class GradleTest {
   fun gradleRunner(vararg arguments: String): GradleRunner {
     return GradleRunner.create()
         .withProjectDir(testProjectDir.root)
-        .withArguments(arguments.asList())
+        .withArguments(arguments.asList() + "-Pdry=true")
         .withPluginClasspath()
   }
 }

--- a/src/test/resources/app/ftl-credentials.json
+++ b/src/test/resources/app/ftl-credentials.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "mock-project-id",
+  "private_key_id": "",
+  "private_key": "",
+  "client_email": "",
+  "client_id": "",
+  "auth_uri": "",
+  "token_uri": "",
+  "auth_provider_x509_cert_url": "",
+  "client_x509_cert_url": ""
+}

--- a/src/test/resources/library/some-credentials.json
+++ b/src/test/resources/library/some-credentials.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "mock-project-id",
+  "private_key_id": "",
+  "private_key": "",
+  "client_email": "",
+  "client_id": "",
+  "auth_uri": "",
+  "token_uri": "",
+  "auth_provider_x509_cert_url": "",
+  "client_x509_cert_url": ""
+}


### PR DESCRIPTION
closes #1 , closes #4 

Instead of creating integrationTest and require FTL credentials I decided to use the --dry option from Flank and make credentials unnecessary.