### PR TITLE
Don't add tasks to the rootProject

### DIFF
--- a/src/main/kotlin/io/github/flank/gradle/tasks/CopySmallAppTask.kt
+++ b/src/main/kotlin/io/github/flank/gradle/tasks/CopySmallAppTask.kt
@@ -23,13 +23,13 @@ constructor(
   private val apkName = "small-app.apk"
 
   @OutputFile
-  val appApk: Provider<RegularFile> = projectLayout.buildDirectory.file("$path/smallApp/$apkName")
+  val appApk: Provider<RegularFile> = projectLayout.buildDirectory.file("smallApp/$apkName")
 
   @TaskAction
   fun run() {
     fileSystemOperations.copy {
       from({ pluginJar.single { it.name == apkName }.path })
-      into(projectLayout.buildDirectory.file("$path/smallApp/").get())
+      into(projectLayout.buildDirectory.dir("smallApp/"))
     }
   }
 }

--- a/src/main/kotlin/io/github/flank/gradle/utils/smallAppUtils.kt
+++ b/src/main/kotlin/io/github/flank/gradle/utils/smallAppUtils.kt
@@ -5,7 +5,7 @@ import io.github.flank.gradle.tasks.CopySmallAppTask
 import org.gradle.api.Project
 
 fun Project.getSmallAppTask(): CopySmallAppTask =
-    rootProject.tasks.maybeCreate("copySmallApp", CopySmallAppTask::class.java).apply {
+    tasks.maybeCreate("copySmallApp", CopySmallAppTask::class.java).apply {
       pluginJar.setFrom(
           zipTree(
               SimpleFlankExtension::class.java.classLoader.getResource("small-app.apk")!!


### PR DESCRIPTION
It works (I had a bug, so it didn't really work always) but it's not a good practice to modify the rootProject from the subprojects.
It was a premature optimization to reduce the number of tasks and copies of the credentials and smallApp