### PR TITLE
Allow authentication with Google Accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ plugins {
 }
 ```
 
-add your firebase credentials to the rootproject as `ftl-credentials.json`
+add your firebase credentials to the rootproject as `ftl-credentials.json` or authenticate with your Google Account with `./gradlew flankAuth`
 
 That's it, run `./gradlew flankRun` and get the results.
 

--- a/src/main/kotlin/io/github/flank/gradle/SimpleFlankExtension.kt
+++ b/src/main/kotlin/io/github/flank/gradle/SimpleFlankExtension.kt
@@ -10,8 +10,19 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.property
 
-abstract class SimpleFlankExtension(project: Project) {
-  val credentialsFile: RegularFileProperty = project.objects.fileProperty()
+abstract class SimpleFlankExtension(private val project: Project) {
+  private val optionalDefaultCredentialFileProvider =
+      project.objects.fileProperty().apply {
+        // Se set the default credentials file only if exists already at configuration time.
+        // When the credentials are not there, clients can use the extension.
+        val defaultCredentialsFile = project.rootProject.file("ftl-credentials.json")
+        if (defaultCredentialsFile.exists()) {
+          value { defaultCredentialsFile }
+        }
+      }
+
+  val credentialsFile: RegularFileProperty =
+      project.objects.fileProperty().convention(optionalDefaultCredentialFileProvider)
 
   val projectId: Property<String> =
       project

--- a/src/main/kotlin/io/github/flank/gradle/SimpleFlankExtension.kt
+++ b/src/main/kotlin/io/github/flank/gradle/SimpleFlankExtension.kt
@@ -13,7 +13,6 @@ import org.gradle.kotlin.dsl.property
 abstract class SimpleFlankExtension(private val project: Project) {
   val credentialsFile: RegularFileProperty =
       project.objects.fileProperty().convention { project.rootProject.file("ftl-credentials.json") }
-
   val projectId: Property<String> =
       project
           .objects

--- a/src/main/kotlin/io/github/flank/gradle/SimpleFlankExtension.kt
+++ b/src/main/kotlin/io/github/flank/gradle/SimpleFlankExtension.kt
@@ -11,18 +11,8 @@ import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.property
 
 abstract class SimpleFlankExtension(private val project: Project) {
-  private val optionalDefaultCredentialFileProvider =
-      project.objects.fileProperty().apply {
-        // Se set the default credentials file only if exists already at configuration time.
-        // When the credentials are not there, clients can use the extension.
-        val defaultCredentialsFile = project.rootProject.file("ftl-credentials.json")
-        if (defaultCredentialsFile.exists()) {
-          value { defaultCredentialsFile }
-        }
-      }
-
   val credentialsFile: RegularFileProperty =
-      project.objects.fileProperty().convention(optionalDefaultCredentialFileProvider)
+      project.objects.fileProperty().convention { project.rootProject.file("ftl-credentials.json") }
 
   val projectId: Property<String> =
       project

--- a/src/main/kotlin/io/github/flank/gradle/SimpleFlankExtension.kt
+++ b/src/main/kotlin/io/github/flank/gradle/SimpleFlankExtension.kt
@@ -10,9 +10,9 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.property
 
-abstract class SimpleFlankExtension(private val project: Project) {
-  val credentialsFile: RegularFileProperty =
-      project.objects.fileProperty().convention { project.rootProject.file("ftl-credentials.json") }
+abstract class SimpleFlankExtension(project: Project) {
+  val credentialsFile: RegularFileProperty = project.objects.fileProperty()
+
   val projectId: Property<String> =
       project
           .objects

--- a/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
+++ b/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
@@ -128,7 +128,7 @@ fun registerFlankRun(
     tasks.register<FlankRunTask>("flankRun${variant.name.capitalize()}") {
       flankJarClasspath.from(flankExecutable)
 
-      serviceAccountCredentials.value(simpleFlankExtension.credentialsFile)
+      serviceAccountCredentials.convention(simpleFlankExtension.credentialsFile)
       flankAuthDirectory.set(File(System.getProperty("user.home")).resolve(".flank"))
       this@register.variant.convention(variant.name)
       hermeticTests.convention(simpleFlankExtension.hermeticTests)

--- a/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
+++ b/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
@@ -129,17 +129,14 @@ fun registerFlankRun(
       flankJarClasspath.from(flankExecutable)
 
       serviceAccountCredentials.value(
-        simpleFlankExtension.credentialsFile
-          .convention(
-            objects.fileProperty().let { property ->
-              // Se set the default credentials file only if exists already at configuration time.
-              // When the credentials are not there, clients can use the extension.
-              val defaultCredentialsFile = rootProject.file("ftl-credentials.json")
-              if (defaultCredentialsFile.exists()) property.value { defaultCredentialsFile }
-              else property
-            }
-          )
-      )
+          simpleFlankExtension.credentialsFile.convention(
+              objects.fileProperty().let { property ->
+                // Se set the default credentials file only if exists already at configuration time.
+                // When the credentials are not there, clients can use the extension.
+                val defaultCredentialsFile = rootProject.file("ftl-credentials.json")
+                if (defaultCredentialsFile.exists()) property.value { defaultCredentialsFile }
+                else property
+              }))
       this@register.variant.convention(variant.name)
       hermeticTests.convention(simpleFlankExtension.hermeticTests)
       this.appApk.convention(appApk)
@@ -188,7 +185,5 @@ fun registerRunFlankTask() {
 }
 
 fun registerAuthTask() {
-  tasks.register<FlankAuthTask>("flankAuth") {
-    flankJarClasspath.from(flankExecutable)
-  }
+  tasks.register<FlankAuthTask>("flankAuth") { flankJarClasspath.from(flankExecutable) }
 }

--- a/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
+++ b/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
@@ -129,6 +129,7 @@ fun registerFlankRun(
       flankJarClasspath.from(flankExecutable)
 
       serviceAccountCredentials.value(simpleFlankExtension.credentialsFile)
+      flankAuthDirectory.set(File(System.getProperty("user.home")).resolve(".flank"))
       this@register.variant.convention(variant.name)
       hermeticTests.convention(simpleFlankExtension.hermeticTests)
       this.appApk.convention(appApk)

--- a/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
+++ b/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
@@ -128,15 +128,7 @@ fun registerFlankRun(
     tasks.register<FlankRunTask>("flankRun${variant.name.capitalize()}") {
       flankJarClasspath.from(flankExecutable)
 
-      serviceAccountCredentials.value(
-          simpleFlankExtension.credentialsFile.convention(
-              objects.fileProperty().let { property ->
-                // Se set the default credentials file only if exists already at configuration time.
-                // When the credentials are not there, clients can use the extension.
-                val defaultCredentialsFile = rootProject.file("ftl-credentials.json")
-                if (defaultCredentialsFile.exists()) property.value { defaultCredentialsFile }
-                else property
-              }))
+      serviceAccountCredentials.value(simpleFlankExtension.credentialsFile)
       this@register.variant.convention(variant.name)
       hermeticTests.convention(simpleFlankExtension.hermeticTests)
       this.appApk.convention(appApk)

--- a/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
+++ b/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
@@ -128,7 +128,18 @@ fun registerFlankRun(
     tasks.register<FlankRunTask>("flankRun${variant.name.capitalize()}") {
       flankJarClasspath.from(flankExecutable)
 
-      serviceAccountCredentials.convention(simpleFlankExtension.credentialsFile)
+      serviceAccountCredentials.value(
+        simpleFlankExtension.credentialsFile
+          .convention(
+            objects.fileProperty().let { property ->
+              // Se set the default credentials file only if exists already at configuration time.
+              // When the credentials are not there, clients can use the extension.
+              val defaultCredentialsFile = rootProject.file("ftl-credentials.json")
+              if (defaultCredentialsFile.exists()) property.value { defaultCredentialsFile }
+              else property
+            }
+          )
+      )
       this@register.variant.convention(variant.name)
       hermeticTests.convention(simpleFlankExtension.hermeticTests)
       this.appApk.convention(appApk)

--- a/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
+++ b/src/main/kotlin/io/github/flank/gradle/simple-flank.gradle.kts
@@ -49,6 +49,7 @@ plugins.withType<AppPlugin> {
   }
   tasks.register<FlankVersionTask>("flankVersion") { flankJarClasspath.from(flankExecutable) }
   registerRunFlankTask()
+  registerAuthTask()
 }
 
 plugins.withType<LibraryPlugin> {
@@ -73,6 +74,7 @@ plugins.withType<LibraryPlugin> {
   }
   tasks.register<FlankVersionTask>("flankVersion") { flankJarClasspath.from(flankExecutable) }
   registerRunFlankTask()
+  registerAuthTask()
 }
 
 fun registerFlankYamlWriter(
@@ -171,5 +173,11 @@ fun registerRunFlankTask() {
     group = Test.TASK_GROUP
     description = "Run all androidTest using flank."
     dependsOn(tasks.withType<FlankRunTask>())
+  }
+}
+
+fun registerAuthTask() {
+  tasks.register<FlankAuthTask>("flankAuth") {
+    flankJarClasspath.from(flankExecutable)
   }
 }

--- a/src/main/kotlin/io/github/flank/gradle/tasks/FlankAuthTask.kt
+++ b/src/main/kotlin/io/github/flank/gradle/tasks/FlankAuthTask.kt
@@ -1,0 +1,33 @@
+package io.github.flank.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class FlankAuthTask @Inject constructor(
+  private val execOperations: ExecOperations
+) : DefaultTask() {
+  @get:InputFiles
+  @get:Classpath
+  abstract val flankJarClasspath: ConfigurableFileCollection
+
+  init {
+    group = "flank"
+    description = "Performs the authentication with a Google Account. https://flank.github.io/flank/#authenticate-with-a-google-account"
+  }
+
+  @TaskAction
+  fun run() {
+    execOperations
+      .javaexec {
+        classpath = flankJarClasspath
+        mainClass.set("ftl.Main")
+        args = listOf("auth", "login")
+      }
+      .assertNormalExitValue()
+  }
+}

--- a/src/main/kotlin/io/github/flank/gradle/tasks/FlankAuthTask.kt
+++ b/src/main/kotlin/io/github/flank/gradle/tasks/FlankAuthTask.kt
@@ -1,33 +1,31 @@
 package io.github.flank.gradle.tasks
 
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
-import javax.inject.Inject
 
-abstract class FlankAuthTask @Inject constructor(
-  private val execOperations: ExecOperations
-) : DefaultTask() {
-  @get:InputFiles
-  @get:Classpath
-  abstract val flankJarClasspath: ConfigurableFileCollection
+abstract class FlankAuthTask @Inject constructor(private val execOperations: ExecOperations) :
+    DefaultTask() {
+  @get:InputFiles @get:Classpath abstract val flankJarClasspath: ConfigurableFileCollection
 
   init {
     group = "flank"
-    description = "Performs the authentication with a Google Account. https://flank.github.io/flank/#authenticate-with-a-google-account"
+    description =
+        "Performs the authentication with a Google Account. https://flank.github.io/flank/#authenticate-with-a-google-account"
   }
 
   @TaskAction
   fun run() {
     execOperations
-      .javaexec {
-        classpath = flankJarClasspath
-        mainClass.set("ftl.Main")
-        args = listOf("auth", "login")
-      }
-      .assertNormalExitValue()
+        .javaexec {
+          classpath = flankJarClasspath
+          mainClass.set("ftl.Main")
+          args = listOf("auth", "login")
+        }
+        .assertNormalExitValue()
   }
 }

--- a/src/main/kotlin/io/github/flank/gradle/tasks/FlankRunTask.kt
+++ b/src/main/kotlin/io/github/flank/gradle/tasks/FlankRunTask.kt
@@ -90,9 +90,7 @@ constructor(
           if (exitValue == NO_TESTS_EXIT_CODE) {
             logger.warn(
                 """
-                ${
-              testApk.get().singleFile().asFile.relativeTo(projectLayout.projectDirectory.asFile)
-            } doesn't contain any test or they are filtered out
+                ${testApk.get().singleFile().asFile.relativeTo(projectLayout.projectDirectory.asFile)} doesn't contain any test or they are filtered out
                 For projects without tests it's better not to apply this plugin, but if you need to apply it, the build 
                 would be faster if you really deactivate the androidTests for this variant, like: 
 

--- a/src/main/kotlin/io/github/flank/gradle/tasks/FlankRunTask.kt
+++ b/src/main/kotlin/io/github/flank/gradle/tasks/FlankRunTask.kt
@@ -75,7 +75,7 @@ constructor(
           isIgnoreExitValue = true
           classpath = flankJarClasspath
           mainClass.set("ftl.Main")
-          serviceAccountCredentials.orNull?.let { credentialsFile ->
+          serviceAccountCredentials.orNull?.takeIf { it.asFile.exists() }?.let { credentialsFile ->
             environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to credentialsFile))
           }
           args = listOf("firebase", "test", "android", "run", "-c=${flankYaml.get()}")

--- a/src/main/kotlin/io/github/flank/gradle/tasks/FlankRunTask.kt
+++ b/src/main/kotlin/io/github/flank/gradle/tasks/FlankRunTask.kt
@@ -26,7 +26,7 @@ constructor(
   @get:Input
   val dry: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(false)
 
-  @get:InputFile
+  @get:InputFiles
   @get:Optional
   @get:PathSensitive(PathSensitivity.NONE)
   abstract val serviceAccountCredentials: RegularFileProperty

--- a/src/main/kotlin/io/github/flank/gradle/tasks/FlankRunTask.kt
+++ b/src/main/kotlin/io/github/flank/gradle/tasks/FlankRunTask.kt
@@ -27,7 +27,6 @@ constructor(
   val dry: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(false)
 
   @get:InputFiles
-  @get:Optional
   @get:PathSensitive(PathSensitivity.NONE)
   abstract val serviceAccountCredentials: RegularFileProperty
 
@@ -75,7 +74,7 @@ constructor(
           isIgnoreExitValue = true
           classpath = flankJarClasspath
           mainClass.set("ftl.Main")
-          serviceAccountCredentials.orNull?.takeIf { it.asFile.exists() }?.let { credentialsFile ->
+          serviceAccountCredentials.get().takeIf { it.asFile.exists() }?.let { credentialsFile ->
             environment(mapOf("GOOGLE_APPLICATION_CREDENTIALS" to credentialsFile))
           }
           args = listOf("firebase", "test", "android", "run", "-c=${flankYaml.get()}")
@@ -104,7 +103,7 @@ constructor(
   }
 
   private fun checkAuthentication() {
-    val isCredentialsFileProvided = serviceAccountCredentials.orNull?.asFile?.exists() ?: false
+    val isCredentialsFileProvided = serviceAccountCredentials.get().asFile.exists()
     val isFlankAuthenticationProvided = flankAuthDirectory.get().asFile.exists()
     check(isCredentialsFileProvided || isFlankAuthenticationProvided) {
       """

--- a/src/test/kotlin/CredentialsTest.kt
+++ b/src/test/kotlin/CredentialsTest.kt
@@ -1,0 +1,66 @@
+import java.io.File
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import strikt.api.expectThat
+import strikt.assertions.contains
+import strikt.gradle.testkit.output
+import strikt.gradle.testkit.taskPaths
+
+class CredentialsTest : GradleTest() {
+  @get:Rule val userHomeDirectory = TemporaryFolder()
+
+  @Test
+  fun `When no service account or flank credentials are provided, build fails`() {
+    projectFromResources("app")
+    File(testProjectDir.root, "ftl-credentials.json").deleteRecursively()
+    File(testProjectDir.root, "build.gradle.kts")
+        .appendText("simpleFlank { projectId.set(\"my-project\") }")
+
+    val build = gradleRunner("flankRun", "--stacktrace").forwardOutput().buildAndFail()
+
+    expectThat(build) {
+      output.contains(
+          "Either a service account credential file should be provided or the flank authentication performed.")
+    }
+    expectThat(build) { taskPaths(TaskOutcome.FAILED).contains(":flankRunDebug") }
+  }
+
+  @Test
+  fun `When service account is provided, build is successful`() {
+    projectFromResources("app")
+
+    val build = gradleRunner("flankRun", "--stacktrace").forwardOutput().build()
+
+    expectThat(build) {
+      output
+          .not()
+          .contains(
+              "Either a service account credential file should be provided or the flank authentication performed.")
+      taskPaths(TaskOutcome.SUCCESS).contains(":flankRunDebug")
+    }
+  }
+
+  @Test
+  fun `When flank Google Account authentication is provided, build is successful`() {
+    projectFromResources("app")
+    File(testProjectDir.root, "ftl-credentials.json").deleteRecursively()
+    File(testProjectDir.root, "build.gradle.kts")
+        .appendText("simpleFlank { projectId.set(\"my-project\") }")
+    userHomeDirectory.root.resolve(".flank").mkdir()
+
+    val build =
+        gradleRunner("flankRun", "-Duser.home=${userHomeDirectory.root.path}", "--stacktrace")
+            .forwardOutput()
+            .build()
+
+    expectThat(build) {
+      output
+          .not()
+          .contains(
+              "Either a service account credential file should be provided or the flank authentication performed.")
+      taskPaths(TaskOutcome.SUCCESS).contains(":flankRunDebug")
+    }
+  }
+}

--- a/src/test/kotlin/CredentialsTest.kt
+++ b/src/test/kotlin/CredentialsTest.kt
@@ -28,10 +28,30 @@ class CredentialsTest : GradleTest() {
   }
 
   @Test
-  fun `When service account is provided, build is successful`() {
+  fun `When service account is provided using the default file, build is successful`() {
     projectFromResources("app")
 
     val build = gradleRunner("flankRun", "--stacktrace").forwardOutput().build()
+
+    expectThat(build) {
+      output
+          .not()
+          .contains(
+              "Either a service account credential file should be provided or the flank authentication performed.")
+      taskPaths(TaskOutcome.SUCCESS).contains(":flankRunDebug")
+    }
+  }
+
+  @Test
+  fun `When service account is provided using the a custom file, build is successful`() {
+    projectFromResources("app")
+
+    val build = gradleRunner("flankRun", "--stacktrace").forwardOutput().build()
+    File(testProjectDir.root, "ftl-credentials.json").deleteRecursively()
+    File(testProjectDir.root, "custom-credentials.json")
+        .appendText("{ \"project_id\": \"custom-project-id\" }")
+    File(testProjectDir.root, "build.gradle.kts")
+        .appendText("simpleFlank { credentialsFile.set(file(\"custom-credentials.json\")) }")
 
     expectThat(build) {
       output


### PR DESCRIPTION
This PR simply allows client to authenticate to Flank with a Google Account instead of a Service Account, as Flank supports out of the box: https://flank.github.io/flank/#authenticate-with-a-google-account