### PR TITLE
0.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.flank.gradle"
-version = "0.3.0"
+version = "0.4.0"
 
 repositories {
     google()


### PR DESCRIPTION
Prepare the new release:

- Upgrade Gradle to 8.1.1 and AGP to 8.0.1 #39 - fixes Configuration Cache issue with Gradle 8
- Allow authentication with Google Accounts  #37  - instead of using service account credentials.